### PR TITLE
BUG008 - Separar calculate entre tratamento de dados do Github e Sonar

### DIFF
--- a/src/core/measures_functions.py
+++ b/src/core/measures_functions.py
@@ -194,7 +194,7 @@ def get_team_throughput(data: dict[str, int]):
     total_issues = data["total_issues"]
     resolved_issues = data["resolved_issues"]
 
-    return 100 * ((resolved_issues / total_issues) if total_issues is not 0 else 0)
+    return 100 * ((resolved_issues / total_issues) if total_issues != 0 else 0)
 
 
 def get_ci_feedback_time(data: dict[str, int]):
@@ -208,4 +208,4 @@ def get_ci_feedback_time(data: dict[str, int]):
     total_builds = data["total_builds"]
     sum_ci_feedback_times = data["sum_ci_feedback_times"]
 
-    return ((sum_ci_feedback_times // total_builds) if total_builds is not 0 else 0)
+    return (sum_ci_feedback_times // total_builds) if total_builds != 0 else 0

--- a/src/core/measures_functions.py
+++ b/src/core/measures_functions.py
@@ -194,7 +194,7 @@ def get_team_throughput(data: dict[str, int]):
     total_issues = data["total_issues"]
     resolved_issues = data["resolved_issues"]
 
-    return 100 * (resolved_issues / total_issues)
+    return 100 * ((resolved_issues / total_issues) if total_issues is not 0 else 0)
 
 
 def get_ci_feedback_time(data: dict[str, int]):
@@ -208,4 +208,4 @@ def get_ci_feedback_time(data: dict[str, int]):
     total_builds = data["total_builds"]
     sum_ci_feedback_times = data["sum_ci_feedback_times"]
 
-    return sum_ci_feedback_times // total_builds
+    return ((sum_ci_feedback_times // total_builds) if total_builds is not 0 else 0)


### PR DESCRIPTION
## Descrição
Atualmente, a utilização do comando calculate no CLI utiliza de uma função do Core que calcula CI_Feedback_time e Throughput, porém essa utilização é composta de uma divisão que não trata o caso de existir um valor 0 (zero) no denominador, o que poderia retornar um erro.

Issue relacionada:
[BUG008](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/59)

## Porque este Pull Request é necessário?
Com essa alteração, evitaremos quaisquer erros de divisão por zero.

## Critérios de aceitação

- [x] Deverá ser previnida a divisão por zero.

Closes #59
