### PR TITLE
bug/019: Divisão por zero no CI_feedback_time e Throughput

### DIFF
--- a/src/core/measures_functions.py
+++ b/src/core/measures_functions.py
@@ -193,6 +193,12 @@ def get_team_throughput(data: dict[str, int]):
     total_issues = data["total_issues"]
     resolved_issues = data["resolved_issues"]
 
+    has_none = total_issues is None
+    has_zero = total_issues == 0
+
+    if has_none or has_zero:
+        return 0
+
     return 100 * (resolved_issues / total_issues)
 
 
@@ -206,5 +212,11 @@ def get_ci_feedback_time(data: dict[str, int]):
 
     total_builds = data["total_builds"]
     sum_ci_feedback_times = data["sum_ci_feedback_times"]
+
+    has_none = total_builds is None
+    has_zero = total_builds == 0
+
+    if has_none or has_zero:
+        return 0
 
     return sum_ci_feedback_times // total_builds

--- a/tests/utils/analysis_data.py
+++ b/tests/utils/analysis_data.py
@@ -97,6 +97,23 @@ EXTRACTED_MEASURES_DATA = {
             ],
         },
         {
+            "key": "ci_feedback_time",
+            "metrics": [
+                {
+                    "key": "total_builds",
+                    "value": [
+                        0.0,
+                    ],
+                },
+                {
+                    "key": "sum_ci_feedback_times",
+                    "value": [
+                        0.0,
+                    ],
+                },
+            ],
+        },
+        {
             "key": "non_complex_file_density",
             "metrics": [
                 {
@@ -211,6 +228,23 @@ EXTRACTED_MEASURES_DATA = {
                 }
             ],
         },
+        {
+            "key": "team_throughput",
+            "metrics": [
+                {
+                    "key": "total_issues",
+                    "value": [
+                        0.0,
+                    ],
+                },
+                {
+                    "key": "resolved_issues",
+                    "value": [
+                        0.0,
+                    ],
+                },
+            ],
+        },
     ]
 }
 
@@ -219,9 +253,11 @@ CALCULATE_MEASURES_RESULT_DATA = {
         {"key": "passed_tests", "value": 1.0},
         {"key": "test_builds", "value": 0.9995933399758454},
         {"key": "test_coverage", "value": 0.23425},
+        {"key": "ci_feedback_time", "value": 0.0},
         {"key": "non_complex_file_density", "value": 0.8603745807930887},
         {"key": "commented_file_density", "value": 0.0935},
         {"key": "duplication_absense", "value": 0.0},
+        {"key": "team_throughput", "value": 0.0},
     ]
 }
 


### PR DESCRIPTION
bug/019: Divisão por zero no CI_feedback_time e Throughput

## Descrição
Atualmente o sistema não realiza o tratamento de erros para o caso das medidas de total_builds e total_issues estarem vazias para ou iguais a 0 (zero) para CI_feedback_time e Throughput, respectivamente, ao realizar o cálculo de características e subcaracterísticas, o que impede o uso do Core para cálculo.

[BUG019 - Divisão por 0 no cálculo do Team Throughput](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/92)

## Porque este Pull Request é necessário?
A falta de tratamento da possibilidade de divisão por zero tem impedido o desenvolvimento fluído das tarefas que utilizam o cálculo pelo Core.

## Critérios de aceitação

1. [x] O sistema deve retornar zero ao receber valor zerado para total_builds no cálculo do CI_feedback_time;
2. [x] O sistema deve retornar zero ao receber valor zerado para total_issues no cálculo do Throughput;
3. [x] Devem existir testes para ambos os casos;

Closes #92
